### PR TITLE
Check if the user has any tokens before enrolling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+

--- a/src/main/java/org/privacyidea/authenticator/Const.java
+++ b/src/main/java/org/privacyidea/authenticator/Const.java
@@ -67,6 +67,7 @@ final class Const {
     static final String JSON_KEY_MESSAGES = "messages";
     static final String JSON_KEY_TRANSACTION_IDS = "transaction_ids";
     static final String JSON_KEY_TOKENS = "tokens";
+    static final String JSON_KEY_COUNT = "count";
 
     static final String CONFIG_PUSHTOKENINTERVAL = "pipushtokeninterval";
     static final String CONFIG_EXCLUDEGROUPS = "piexcludegroups";

--- a/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java
+++ b/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java
@@ -122,28 +122,37 @@ public class PrivacyIDEAAuthenticator implements org.keycloak.authentication.Aut
 
         // Enroll token if enabled and user does not have one (counted from trigger challenge)
         String tokenEnrollmentQR = "";
-        if (_config.doEnrollToken() && tokenCounter == 0) {
-            // Check if user has a token
-            Map<String, String> params = new HashMap<>();
-            params.put(PARAM_KEY_USER, _currentUserName);
-            /*JsonObject response = _endpoint.sendRequest(ENDPOINT_TOKEN, params, true, GET);
-
-            JsonObject result = response.getJsonObject(JSON_KEY_RESULT);
-            JsonObject value = result.getJsonObject(JSON_KEY_VALUE);
-            JsonArray tokens = value.getJsonArray(JSON_KEY_TOKENS);
-            log.info("tokens size:" + tokens.size()); */
-            //if (tokens.size() < 1) {
-            params.put(PARAM_KEY_TYPE, _config.getEnrollingTokenType());
-            params.put(PARAM_KEY_GENKEY, "1");
-            JsonObject response = _endpoint.sendRequest(ENDPOINT_TOKEN_INIT, params, true, POST);
+        if (_config.doEnrollToken()) {
             try {
-                JsonObject detail = response.getJsonObject(JSON_KEY_DETAIL);
-                JsonObject googleurl = detail.getJsonObject(JSON_KEY_GOOGLEURL);
-                tokenEnrollmentQR = googleurl.getString(JSON_KEY_IMG);
+                // get the current list of tokens for a user
+                Map<String, String> params = new HashMap<>();
+                params.put(PARAM_KEY_USER, _currentUserName);
+                JsonObject body = _endpoint.sendRequest(ENDPOINT_TOKEN, params, true, GET);
+                JsonObject value = body.getJsonObject(JSON_KEY_RESULT).getJsonObject(JSON_KEY_VALUE);
+                tokenCounter = value.getInt(JSON_KEY_COUNT, 0);
+
+                // Check if user has a token
+                if (tokenCounter != 0) {
+                    params = new HashMap<>();
+                    params.put(PARAM_KEY_USER, _currentUserName);
+                    /*JsonObject response = _endpoint.sendRequest(ENDPOINT_TOKEN, params, true, GET);
+
+                    JsonObject result = response.getJsonObject(JSON_KEY_RESULT);
+                    JsonObject value = result.getJsonObject(JSON_KEY_VALUE);
+                    JsonArray tokens = value.getJsonArray(JSON_KEY_TOKENS);
+                    log.info("tokens size:" + tokens.size()); */
+                    //if (tokens.size() < 1) {
+                    params.put(PARAM_KEY_TYPE, _config.getEnrollingTokenType());
+                    params.put(PARAM_KEY_GENKEY, "1");
+                    JsonObject response = _endpoint.sendRequest(ENDPOINT_TOKEN_INIT, params, true, POST);
+                    JsonObject detail = response.getJsonObject(JSON_KEY_DETAIL);
+                    JsonObject googleurl = detail.getJsonObject(JSON_KEY_GOOGLEURL);
+                    tokenEnrollmentQR = googleurl.getString(JSON_KEY_IMG);
+                }
             } catch (Exception e) {
-                _log.error("Token enrollment failed");
+                _log.error(e);
+                _log.error("Token enrollment was not successful.");
             }
-            //}
         }
         context.getAuthenticationSession().setAuthNote(AUTH_NOTE_AUTH_COUNTER, "0");
 

--- a/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java
+++ b/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java
@@ -120,28 +120,20 @@ public class PrivacyIDEAAuthenticator implements org.keycloak.authentication.Aut
             }
         }
 
-        // Enroll token if enabled and user does not have one (counted from trigger challenge)
+        // Enroll token if enabled and user does not have one
         String tokenEnrollmentQR = "";
         if (_config.doEnrollToken()) {
             try {
-                // get the current list of tokens for a user
+                // Get the current list of tokens for the user
                 Map<String, String> params = new HashMap<>();
                 params.put(PARAM_KEY_USER, _currentUserName);
                 JsonObject body = _endpoint.sendRequest(ENDPOINT_TOKEN, params, true, GET);
                 JsonObject value = body.getJsonObject(JSON_KEY_RESULT).getJsonObject(JSON_KEY_VALUE);
                 tokenCounter = value.getInt(JSON_KEY_COUNT, 0);
-
-                // Check if user has a token
-                if (tokenCounter != 0) {
+                if (tokenCounter < 1) {
+                    // User has no tokens - request rollout
                     params = new HashMap<>();
                     params.put(PARAM_KEY_USER, _currentUserName);
-                    /*JsonObject response = _endpoint.sendRequest(ENDPOINT_TOKEN, params, true, GET);
-
-                    JsonObject result = response.getJsonObject(JSON_KEY_RESULT);
-                    JsonObject value = result.getJsonObject(JSON_KEY_VALUE);
-                    JsonArray tokens = value.getJsonArray(JSON_KEY_TOKENS);
-                    log.info("tokens size:" + tokens.size()); */
-                    //if (tokens.size() < 1) {
                     params.put(PARAM_KEY_TYPE, _config.getEnrollingTokenType());
                     params.put(PARAM_KEY_GENKEY, "1");
                     JsonObject response = _endpoint.sendRequest(ENDPOINT_TOKEN_INIT, params, true, POST);

--- a/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticatorFactory.java
+++ b/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticatorFactory.java
@@ -1,7 +1,6 @@
 package org.privacyidea.authenticator;
 
 import org.keycloak.Config;
-import org.keycloak.authentication.ConfigurableAuthenticatorFactory;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
@@ -34,7 +33,7 @@ import static org.privacyidea.authenticator.Const.*;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-public class PrivacyIDEAAuthenticatorFactory implements org.keycloak.authentication.AuthenticatorFactory, ConfigurableAuthenticatorFactory {
+public class PrivacyIDEAAuthenticatorFactory implements org.keycloak.authentication.AuthenticatorFactory, org.keycloak.authentication.ConfigurableAuthenticatorFactory {
 
     private static final PrivacyIDEAAuthenticator SINGLETON = new PrivacyIDEAAuthenticator();
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
@@ -79,7 +78,7 @@ public class PrivacyIDEAAuthenticatorFactory implements org.keycloak.authenticat
         piServerUrl.setType(ProviderConfigProperty.STRING_TYPE);
         piServerUrl.setName(CONFIG_SERVER);
         piServerUrl.setLabel("URL");
-        piServerUrl.setHelpText("The URL of the privacyIDEA server");
+        piServerUrl.setHelpText("The URL of the privacyIDEA server (complete with scheme, host and port like \"https://<piserver>:port\")");
         configProperties.add(piServerUrl);
 
         ProviderConfigProperty piRealm = new ProviderConfigProperty();
@@ -128,7 +127,7 @@ public class PrivacyIDEAAuthenticatorFactory implements org.keycloak.authenticat
         piEnrollToken.setType(ProviderConfigProperty.BOOLEAN_TYPE);
         piEnrollToken.setName(CONFIG_ENROLLTOKEN);
         piEnrollToken.setLabel("Enable token enrollment");
-        piEnrollToken.setHelpText("If enabled, the users can enroll a token themselves, if they do not have one yet. Trigger Challenge has to be enabled and a service account is needed");
+        piEnrollToken.setHelpText("If enabled, the user gets a token enrolled automatically for them, if they do not have one yet. The Service account is needed");
         piEnrollToken.setDefaultValue("false");
         configProperties.add(piEnrollToken);
 
@@ -138,7 +137,7 @@ public class PrivacyIDEAAuthenticatorFactory implements org.keycloak.authenticat
         ProviderConfigProperty piTokenType = new ProviderConfigProperty();
         piTokenType.setType(ProviderConfigProperty.LIST_TYPE);
         piTokenType.setName(CONFIG_ENROLLTOKENTYPE);
-        piTokenType.setLabel("Token type");
+        piTokenType.setLabel("Enrollment Token type");
         piTokenType.setHelpText("Select the token type that users can enroll, if they do not have a token yet. Service account is needed");
         piTokenType.setOptions(tokenTypes);
         piTokenType.setDefaultValue("HOTP");


### PR DESCRIPTION
Using the `triggerchallenge` endpoint to get the number of tokens of a user
is insufficient since token types like `SPASS` won't show up.
This adds another API call to get the correct number of tokens for a user.