### PR TITLE
Fix Cancel Button at authentification OTP

### DIFF
--- a/privacyIDEA.ftl
+++ b/privacyIDEA.ftl
@@ -75,7 +75,7 @@
                             }
                         </script>
                         <input class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}"
-                               name="cancel" id="kc-cancel" type="submit" value="${msg("doCancel")}"/>
+                               onClick="window.history.go(-1)" name="cancel" id="kc-cancel" type="submit" value="${msg("doCancel")}"/>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
the cancel button didn't work, with this fix we go one side back in browser history. (Login Screen).

fixes: #22 