### PR TITLE
change url input field type, upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,19 +38,19 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
-            <version>9.0.0</version>
+            <version>9.0.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi-private</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.3</version>
         </dependency>
 
         <dependency>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.3</version>
         </dependency>
 
         <dependency>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-common</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.3</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticatorFactory.java
+++ b/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticatorFactory.java
@@ -75,7 +75,7 @@ public class PrivacyIDEAAuthenticatorFactory implements org.keycloak.authenticat
 
     static {
         ProviderConfigProperty piServerUrl = new ProviderConfigProperty();
-        piServerUrl.setType(ProviderConfigProperty.STRING_TYPE);
+        piServerUrl.setType(ProviderConfigProperty.TEXT_TYPE);
         piServerUrl.setName(CONFIG_SERVER);
         piServerUrl.setLabel("URL");
         piServerUrl.setHelpText("The URL of the privacyIDEA server (complete with scheme, host and port like \"https://<piserver>:port\")");


### PR DESCRIPTION
* change input type of url field in configuration to TEXT because the before used STRING type does not allow to use characters like ':' or '/' anymore
* update keycloak dependencies to version 9.0.3
* fixes #35 