### PR TITLE
121 add preferred client mode

### DIFF
--- a/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java
+++ b/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java
@@ -471,8 +471,6 @@ public class PrivacyIDEAAuthenticator implements org.keycloak.authentication.Aut
             }
         }
 
-
-
         context.form().setAttribute(FORM_MODE, mode).setAttribute(FORM_WEBAUTHN_SIGN_REQUEST, webAuthnSignRequest)
                .setAttribute(FORM_U2F_SIGN_REQUEST, u2fSignRequest);
     }

--- a/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java
+++ b/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java
@@ -457,11 +457,21 @@ public class PrivacyIDEAAuthenticator implements org.keycloak.authentication.Aut
             }
         }
 
-        // Check if any triggered token matches the preferred token type
-        if (response.triggeredTokenTypes().contains(config.prefTokenType()))
+        // Check if server response contains preferred client mode
+        if (response.preferredClientMode != null && !response.preferredClientMode.isEmpty())
         {
-            mode = config.prefTokenType();
+            mode = response.preferredClientMode;
         }
+        else
+        {
+            // Check if any triggered token matches the preferred token type
+            if (response.triggeredTokenTypes().contains(config.prefTokenType()))
+            {
+                mode = config.prefTokenType();
+            }
+        }
+
+
 
         context.form().setAttribute(FORM_MODE, mode).setAttribute(FORM_WEBAUTHN_SIGN_REQUEST, webAuthnSignRequest)
                .setAttribute(FORM_U2F_SIGN_REQUEST, u2fSignRequest);

--- a/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java
+++ b/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java
@@ -457,7 +457,7 @@ public class PrivacyIDEAAuthenticator implements org.keycloak.authentication.Aut
             }
         }
 
-        // Check if server response contains preferred client mode
+        // Check if response from server contains preferred client mode
         if (response.preferredClientMode != null && !response.preferredClientMode.isEmpty())
         {
             mode = response.preferredClientMode;


### PR DESCRIPTION
In a new version of privacyIDEA response contains the preferred client mode.

Java-Client already updated. Now, implement this enhancement to keycloak.

NOTE: Leave for now the old config option - preferred token type, but in the future it should be removed.