### PR TITLE
kc22 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,10 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <!-- add okhttp3 to the manifest to that the classloader finds it -->
+                            <!-- add included dependencies to the manifest so that the classloader can find them -->
                             <Dependencies>com.squareup.okhttp3</Dependencies>
+                            <Dependencies>org.jetbrains.kotlin</Dependencies>
+                            <Dependencies>com.squareup.okio</Dependencies>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -80,7 +82,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>8</release>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -104,25 +107,31 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
-            <version>22.0.1</version>
+            <version>22.0.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
-            <version>20.0.3</version>
+            <version>22.0.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi-private</artifactId>
-            <version>21.1.2</version>
+            <version>22.0.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
-            <version>21.1.2</version>
+            <version>22.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-common</artifactId>
+            <version>22.0.0</version>
         </dependency>
 
         <dependency>
@@ -132,15 +141,22 @@
         </dependency>
 
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-common</artifactId>
-            <version>19.0.3</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>4.9.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>8.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java
+++ b/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java
@@ -23,13 +23,13 @@
  */
 package org.privacyidea.authenticator;
 
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;


### PR DESCRIPTION
To be able to run on KC22, include jakarta.ws.rs-api dependency. Also add the kotlin-stdlib and okio dependencies to the manifest. They are included in the javaclient.
closing #143