### PR TITLE
177 forward ip as client parameter to privacyidea

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,12 +116,12 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi-private</artifactId>
-            <version>22.0.1</version>
+            <version>25.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
-            <version>24.0.3</version>
+            <version>25.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/src/main/java/org/privacyidea/authenticator/Configuration.java
+++ b/src/main/java/org/privacyidea/authenticator/Configuration.java
@@ -39,6 +39,7 @@ class Configuration
     private final List<String> excludedGroups = new ArrayList<>();
     private final List<String> includedGroups = new ArrayList<>();
     private final List<String> forwardedHeaders = new ArrayList<>();
+    private final boolean forwardClientIP;
     private final String otpLength;
     private final boolean doLog;
     private final boolean pollInBrowser;
@@ -58,6 +59,7 @@ class Configuration
         this.serviceAccountPass = configMap.get(CONFIG_SERVICE_PASS) == null ? "" : configMap.get(CONFIG_SERVICE_PASS);
         this.serviceAccountRealm = configMap.get(CONFIG_SERVICE_REALM) == null ? "" : configMap.get(CONFIG_SERVICE_REALM);
         this.staticPass = configMap.get(CONFIG_STATIC_PASS) == null ? "" : configMap.get(CONFIG_STATIC_PASS);
+        this.forwardClientIP = configMap.get(CONFIG_FORWARD_CLIENT_IP) != null && configMap.get(CONFIG_FORWARD_CLIENT_IP).equals(TRUE);
         this.defaultOTPMessage = configMap.get(CONFIG_DEFAULT_MESSAGE) == null ? "" : configMap.get(CONFIG_DEFAULT_MESSAGE);
         this.otpLength = configMap.get(CONFIG_OTP_LENGTH) == null ? "" : configMap.get(CONFIG_OTP_LENGTH);
         this.pollInBrowser = (configMap.get(CONFIG_POLL_IN_BROWSER) != null && configMap.get(CONFIG_POLL_IN_BROWSER).equals(TRUE));
@@ -175,6 +177,11 @@ class Configuration
     List<String> forwardedHeaders()
     {
         return forwardedHeaders;
+    }
+
+    boolean forwardClientIP()
+    {
+        return forwardClientIP;
     }
 
     String otpLength()

--- a/src/main/java/org/privacyidea/authenticator/Const.java
+++ b/src/main/java/org/privacyidea/authenticator/Const.java
@@ -51,7 +51,6 @@ final class Const
     static final String FORM_POLL_IN_BROWSER_FAILED = "pollInBrowserFailed";
     static final String FORM_ERROR_MESSAGE = "errorMsg";
     static final String FORM_TRANSACTION_ID = "transactionID";
-    static final String FORM_PI_SERVER_URL = "piServerUrl";
     static final String FORM_AUTO_SUBMIT_OTP_LENGTH = "AutoSubmitOtpLength";
     static final String FORM_POLL_IN_BROWSER_URL = "pollInBrowserUrl";
     static final String FORM_PUSH_AVAILABLE = "pushAvailable";
@@ -71,13 +70,13 @@ final class Const
 
     static final String AUTH_NOTE_TRANSACTION_ID = "transaction_id";
     static final String AUTH_NOTE_AUTH_COUNTER = "authCounter";
-    static final String AUTH_NOTE_ACCEPT_LANGUAGE = "authLanguage";
 
     // Changing the config value names will reset the current config
     static final String CONFIG_PUSH_INTERVAL = "pipushtokeninterval";
     static final String CONFIG_EXCLUDED_GROUPS = "piexcludegroups";
     static final String CONFIG_INCLUDED_GROUPS = "piincludegroups";
     static final String CONFIG_FORWARDED_HEADERS = "piforwardedheaders";
+    static final String CONFIG_FORWARD_CLIENT_IP = "piforwardclientip";
     static final String CONFIG_DEFAULT_MESSAGE = "pidefaultmessage";
     static final String CONFIG_POLL_IN_BROWSER = "pipollinbrowser";
     static final String CONFIG_POLL_IN_BROWSER_URL = "pipollinbrowserurl";

--- a/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticatorFactory.java
+++ b/src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticatorFactory.java
@@ -159,6 +159,14 @@ public class PrivacyIDEAAuthenticatorFactory implements org.keycloak.authenticat
                                  + "Can be empty to send an empty password.");
         configProperties.add(piStaticPass);
 
+        ProviderConfigProperty piForwardClientIP = new ProviderConfigProperty();
+        piForwardClientIP.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        piForwardClientIP.setName(Const.CONFIG_FORWARD_CLIENT_IP);
+        piForwardClientIP.setLabel("Forward client IP");
+        piForwardClientIP.setHelpText("Enable this to forward the client IP to privacyIDEA. "
+                                      + "This can be used in privacyIDEA server if configured.");
+        configProperties.add(piForwardClientIP);
+
         ProviderConfigProperty piIncludeGroups = new ProviderConfigProperty();
         piIncludeGroups.setType(ProviderConfigProperty.STRING_TYPE);
         piIncludeGroups.setName(Const.CONFIG_INCLUDED_GROUPS);
@@ -214,7 +222,7 @@ public class PrivacyIDEAAuthenticatorFactory implements org.keycloak.authenticat
         ProviderConfigProperty piPollInBrowserUrl = new ProviderConfigProperty();
         piPollInBrowserUrl.setType(ProviderConfigProperty.STRING_TYPE);
         piPollInBrowserUrl.setName(Const.CONFIG_POLL_IN_BROWSER_URL);
-        piPollInBrowserUrl.setLabel("Url for poll in browser");
+        piPollInBrowserUrl.setLabel("URL for poll in browser");
         piPollInBrowserUrl.setHelpText("Optional. If poll in browser should use a deviating URL, set it here. "
                                        + "Otherwise, the general URL will be used.");
         configProperties.add(piPollInBrowserUrl);

--- a/src/main/resources/theme-resources/resources/js/pi-utils.js
+++ b/src/main/resources/theme-resources/resources/js/pi-utils.js
@@ -1,13 +1,13 @@
 window.piGetValue = function getValue (id) {
     const element = document.getElementById(id);
-    if (element === null)
+    if (element !== null)
     {
-        console.log(id + " is null!");
-        return "";
+        return element.value;
     }
     else
     {
-        return element.value;
+        console.log(id + " is null!");
+        return "";
     }
 }
 


### PR DESCRIPTION
This pull request includes several updates to the `PrivacyIDEAAuthenticator` project, focusing on adding new configuration options and improving existing functionality. The most important changes include updating dependencies, adding the ability to forward the client IP to privacyIDEA server, and fixing some minor issues.

Dependency updates:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L119-R124): Updated the `keycloak-server-spi-private` and `keycloak-services` dependencies to version 25.0.1.

New features:
* [`src/main/java/org/privacyidea/authenticator/Configuration.java`](diffhunk://#diff-321994e6a006fd379d84cf9e38c4aa371867c099d3dcae684b661f9c13642892R42): Added a new configuration option `forwardClientIP` to forward the client IP address. [[1]](diffhunk://#diff-321994e6a006fd379d84cf9e38c4aa371867c099d3dcae684b661f9c13642892R42) [[2]](diffhunk://#diff-321994e6a006fd379d84cf9e38c4aa371867c099d3dcae684b661f9c13642892R62) [[3]](diffhunk://#diff-321994e6a006fd379d84cf9e38c4aa371867c099d3dcae684b661f9c13642892R182-R186)
* [`src/main/java/org/privacyidea/authenticator/Const.java`](diffhunk://#diff-7132c091aaa79d9b66c486e636a15bd2ab23eb167f1ff15632765435de5fec92R72): Added a constant for the new configuration option `CONFIG_FORWARD_CLIENT_IP`.
* [`src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java`](diffhunk://#diff-0e8cdfe80e57354c310e68c2cc4c27f9b3caac83347d0e211e9f9aff6ca10c3aL81-R88): Modified the `loadConfiguration` method to use the `forwardClientIP` configuration option.

Bug fixes and improvements:
* [`src/main/java/org/privacyidea/authenticator/PrivacyIDEAAuthenticator.java`](diffhunk://#diff-0e8cdfe80e57354c310e68c2cc4c27f9b3caac83347d0e211e9f9aff6ca10c3aL216-R217): Corrected the capitalization of `multiChallenge` in several places. [[1]](diffhunk://#diff-0e8cdfe80e57354c310e68c2cc4c27f9b3caac83347d0e211e9f9aff6ca10c3aL216-R217) [[2]](diffhunk://#diff-0e8cdfe80e57354c310e68c2cc4c27f9b3caac83347d0e211e9f9aff6ca10c3aL359-R363) [[3]](diffhunk://#diff-0e8cdfe80e57354c310e68c2cc4c27f9b3caac83347d0e211e9f9aff6ca10c3aL408-R419)
* [`src/main/resources/theme-resources/resources/js/pi-utils.js`](diffhunk://#diff-8cdb7293422ead69b4b473c00b4ba16214c69a2b6c45bfce5858ce41801f3575L3-R10): Fixed the `piGetValue` function to return the element's value if it is not null.